### PR TITLE
expand the use of '~' in cache path location

### DIFF
--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -107,7 +107,7 @@ class ForemanInventory(object):
 
         # Cache related
         try:
-            cache_path = config.get('cache', 'path')
+            cache_path = os.path.expanduser(config.get('cache', 'path'))
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             cache_path = '.'
         (script, ext) = os.path.splitext(os.path.basename(__file__))


### PR DESCRIPTION
Apply a bit more intelligence to the config parser. This allows the
cache files to be anchored within a homedir.

```
[cache]
path = ~/.ansible/tmp
```
