### PR TITLE
Don't fail if host disappears

### DIFF
--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -133,7 +133,7 @@ class ForemanInventory(object):
                             help='Force refresh of cache by making API requests to foreman (default: False - use cache files)')
         self.args = parser.parse_args()
 
-    def _get_json(self, url):
+    def _get_json(self, url, ignore_errors=None):
         page = 1
         results = []
         while True:
@@ -141,6 +141,8 @@ class ForemanInventory(object):
                                auth=HTTPBasicAuth(self.foreman_user, self.foreman_pw),
                                verify=self.foreman_ssl_verify,
                                params={'page': page, 'per_page': 250})
+            if ignore_errors and ret.status_code in ignore_errors:
+                break
             ret.raise_for_status()
             json = ret.json()
             if not json.has_key('results'):
@@ -162,7 +164,7 @@ class ForemanInventory(object):
 
     def _get_params_by_id(self, hid):
         url = "%s/api/v2/hosts/%s/parameters" % (self.foreman_url, hid)
-        return self._get_json(url)
+        return self._get_json(url, [404])
 
     def _resolve_params(self, host):
         """


### PR DESCRIPTION
A host might disappear once we query its params. Don't fail like

Traceback (most recent call last):
 File "inventory", line 295, in <module>
   ForemanInventory()
 File "inventory", line 52, in **init**
   self.update_cache()
 File "inventory", line 204, in update_cache
   params = self._resolve_params(host)
 File "inventory", line 180, in _resolve_params
   paramgroups += [self._get_params_by_id(host['id'])]
 File "inventory", line 158, in _get_params_by_id
   return self._get_json(url)
 File "inventory", line 137, in _get_json
   ret.raise_for_status()
 File "models.py", line 840, in raise_for_status
   raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https:parameters?per_page=250&page=1>

in this case. We need to do this for disappearing host groups, locations
and organizations as well at a later point but VMs disappaer much more
frequently..
