### PR TITLE
Use Foreman to calculate resulting set of params

### DIFF
--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -104,6 +104,11 @@ class ForemanInventory(object):
         self.foreman_pw = config.get('foreman', 'password')
         self.foreman_ssl_verify = config.getboolean('foreman', 'ssl_verify')
 
+        if config.has_option('foreman', 'server_param_resolution'):
+            self.foreman_server_param_resolution = config.getboolean('foreman', 'server_param_resolution')
+        else:
+            self.foreman_server_param_resolution = False
+
         # Ansible related
         try:
             group_patterns = config.get('ansible', 'group_patterns')
@@ -168,28 +173,34 @@ class ForemanInventory(object):
         return self.hostgroups[hid]
 
     def _get_params_by_id(self, hid):
-        url = "%s/api/v2/hosts/%s/parameters" % (self.foreman_url, hid)
-        return self._get_json(url, [404])
+        if not self.foreman_server_param_resolution:
+            url = "%s/api/v2/hosts/%s/parameters" % (self.foreman_url, hid)
+            return self._get_json(url, [404])
+        else:
+            url = "%s/api/v2/hosts/%s" % (self.foreman_url, hid)
+            host = self._get_json(url, [404])
+            return host["all_parameters"] if "all_parameters" in host.keys() else {}
 
     def _resolve_params(self, host):
         """
         Resolve all host group params of the host using the top level
         hostgroup and the ancestry.
         """
-        hostgroup_id = host['hostgroup_id']
         paramgroups = []
         params = {}
 
-        if hostgroup_id:
-            hostgroup = self._get_hostgroup_by_id(hostgroup_id)
-            ancestry_path = hostgroup.get('ancestry', '')
-            ancestry = ancestry_path.split('/') if ancestry_path is not None else []
+        if not self.foreman_server_param_resolution:
+            hostgroup_id = host['hostgroup_id']
+            if hostgroup_id:
+                hostgroup = self._get_hostgroup_by_id(hostgroup_id)
+                ancestry_path = hostgroup.get('ancestry', '')
+                ancestry = ancestry_path.split('/') if ancestry_path is not None else []
 
-            # Append top level hostgroup last to overwrite lower levels
-            # values
-            ancestry.append(hostgroup_id)
-            paramgroups = [self._get_hostgroup_by_id(hostgroup_id)['parameters']
-                           for hostgroup_id in ancestry]
+                # Append top level hostgroup last to overwrite lower levels
+                # values
+                ancestry.append(hostgroup_id)
+                paramgroups = [self._get_hostgroup_by_id(hostgroup_id)['parameters']
+                               for hostgroup_id in ancestry]
 
         paramgroups += [self._get_params_by_id(host['id'])]
         for paramgroup in paramgroups:


### PR DESCRIPTION
I noticed the host returned by Foreman's API contains an `all_parameters` entry which contains Organization / Location / and global as well has host and group parameters.
This would probably be enough to satisfy #9 .
I added an option `server_param_resolution` in the section `foreman` of the ini file to make this change optional and backwards compatible; if missing or set to False, the original behavior is maintained.

It would be nice to have a way to query all_parameters from the API itself instead of having to use the host.
