### PR TITLE
Suppress warning when SSL cert verification is off

### DIFF
--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -107,6 +107,9 @@ class ForemanInventory(object):
         self.foreman_user = config.get('foreman', 'user')
         self.foreman_pw = config.get('foreman', 'password')
         self.foreman_ssl_verify = config.getboolean('foreman', 'ssl_verify')
+        if not self.foreman_ssl_verify:
+            from requests.packages.urllib3.exceptions import InsecureRequestWarning
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
         # Ansible related
         try:


### PR DESCRIPTION
How about suppressing all these warnings?
I'm using self-signed certs so I get a lot of nagging.
I think it can be expected that turning off SSL certificate verification will make the request not be very secure.
