### PR TITLE
Support for complex types (JSON & YAML) without prefix

### DIFF
--- a/foreman.ini
+++ b/foreman.ini
@@ -3,6 +3,7 @@ url = http://localhost:3000/
 user = foreman
 password = secret
 ssl_verify = True
+#complex_types = False
 
 [ansible]
 group_patterns = ["{app}-{tier}-{color}",


### PR DESCRIPTION
Hi,

In case you want more options....

This is the same as #19 but without the prefix, also in reference to issue #17 .

Setting complex_types in the ini file to True (defaults to False) will parse all parameters, first as YAML and then JSON, and if any succeeds it is inserted into the inventory. If both fail, the string is inserted as-is.

This one needs much more testing in the "real world" to ensure it doesn't break existing functionality.
