### PR TITLE
Switch out the shebang to invoke python via /usr/bin/env

### DIFF
--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: set fileencoding=utf-8 :
 #
 # Copyright (C) 2016 Guido Günther <agx@sigxcpu.org>


### PR DESCRIPTION
Figure out the correct location of python via env, thus ensuring that this script plays nice with things like pyenv.
