### PR TITLE
Allow to disable fact cache

### DIFF
--- a/foreman.ini
+++ b/foreman.ini
@@ -10,6 +10,8 @@ group_patterns = ["{app}-{tier}-{color}",
 	          "{app}",
 		  "{tier}"]
 group_prefix = foreman_
+# Whether to fetch facts from Foreman and store them on the host
+want_facts = True
 
 [cache]
 path = .


### PR DESCRIPTION
This brings down inventory generation by about 50% and I doubt lots
of people use it to fetch facts from other hosts.
