### PR TITLE
Add group by Content View and Lifecycle Environment functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ The inventory will provide a set of groups, by default prefixed by
 group_prefix option in /etc/ansible/foreman.ini. The rest of this
 guide will assume the default prefix of 'foreman'
 
-The hostgroup, location and organization of each host are created as
-Ansible groups with a foreman_<grouptype> prefix, all lowercase and
-problematic parameters removed. So e.g. the foreman hostgroup
+The hostgroup, location, organization, content view, and lifecycle
+environment of each host are created as Ansible groups with a 
+foreman_<grouptype> prefix, all lowercase and problematic parameters 
+removed. So e.g. the foreman hostgroup
 
     myapp / webtier / datacenter1
 

--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -23,6 +23,7 @@ import ConfigParser
 import copy
 import os
 import re
+import sys
 from time import time
 import requests
 from requests.auth import HTTPBasicAuth
@@ -229,8 +230,14 @@ class ForemanInventory(object):
             dns_name = host['name']
 
             # Create ansible groups for hostgroup, environment, location and organization
-            for group in ['hostgroup', 'environment', 'location', 'organization']:
+            for group in ['hostgroup', 'environment', 'location', 'organization', 'lifecycle_environment']:
                 val = host.get('%s_name' % group)
+                if val:
+                    safe_key = self.to_safe('%s%s_%s' % (self.group_prefix, group, val.lower()))
+                    self.push(self.inventory, safe_key, dns_name)
+                    
+            for group in ['lifecycle_environment', 'content_view']:
+                val = host.get('content_facet_attributes', {}).get('%s_name' % group)
                 if val:
                     safe_key = self.to_safe('%s%s_%s' % (self.group_prefix, group, val.lower()))
                     self.push(self.inventory, safe_key, dns_name)

--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -23,7 +23,6 @@ import ConfigParser
 import copy
 import os
 import re
-import sys
 from time import time
 import requests
 from requests.auth import HTTPBasicAuth
@@ -230,7 +229,7 @@ class ForemanInventory(object):
             dns_name = host['name']
 
             # Create ansible groups for hostgroup, environment, location and organization
-            for group in ['hostgroup', 'environment', 'location', 'organization', 'lifecycle_environment']:
+            for group in ['hostgroup', 'environment', 'location', 'organization']:
                 val = host.get('%s_name' % group)
                 if val:
                     safe_key = self.to_safe('%s%s_%s' % (self.group_prefix, group, val.lower()))


### PR DESCRIPTION
Users of Satellite 6 need to be able to group by lifecycle environment and content views, functionality provided by Katello rather than Foreman. This PR provides that support.
