### PR TITLE
Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
 install: "pip install -r requirements.txt"
 script:
   - flake8

--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -21,7 +21,6 @@
 from __future__ import print_function
 
 import argparse
-import ConfigParser
 import copy
 import os
 import re
@@ -29,6 +28,12 @@ import requests
 from requests.auth import HTTPBasicAuth
 import sys
 from time import time
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
+
 
 try:
     import json

--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -242,7 +242,7 @@ class ForemanInventory(object):
         if len(ret.values()) == 0:
             facts = {}
         elif len(ret.values()) == 1:
-            facts = ret.values()[0]
+            facts = list(ret.values())[0]
         else:
             raise ValueError("More than one set of facts returned for '%s'" % host)
         return facts

--- a/tests/test_get_json.py
+++ b/tests/test_get_json.py
@@ -25,11 +25,11 @@ class TestGetJson(unittest.TestCase):
                       status=200)
 
         ret = self.inv._get_hosts()
-        self.assertEqual(sorted(ret),
-                         sorted([{u'name': u'foo'},
-                                 {u'name': u'bar'},
-                                 {u'name': u'foo'},
-                                 {u'name': u'bar'}]))
+        self.assertEqual(ret,
+                         [{u'name': u'foo'},
+                          {u'name': u'bar'},
+                          {u'name': u'foo'},
+                          {u'name': u'bar'}])
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[0].request.url,
                          '%s?per_page=250&page=1' % url)

--- a/tests/test_get_json.py
+++ b/tests/test_get_json.py
@@ -2,6 +2,10 @@
 
 import responses
 import unittest
+try:
+    import urlparse
+except ImportError:
+    from urllib import parse as urlparse
 
 from foreman_ansible_inventory import ForemanInventory
 
@@ -13,6 +17,18 @@ class TestGetJson(unittest.TestCase):
         self.inv.foreman_user = 'doesnot'
         self.inv.foreman_pw = 'mastter'
         self.inv.foreman_ssl_verify = True
+
+    def assertEqualUrl(self, url1, url2):
+        p1 = urlparse.urlparse(url1)
+        p2 = urlparse.urlparse(url2)
+        q1 = urlparse.parse_qs(p1.query)
+        q2 = urlparse.parse_qs(p2.query)
+        self.assertEqual(p1.scheme, p2.scheme)
+        self.assertEqual(p1.netloc, p2.netloc)
+        self.assertEqual(p1.path, p2.path)
+        self.assertEqual(p1.params, p2.params)
+        self.assertEqual(p1.fragment, p2.fragment)
+        self.assertEqual(q1, q2)
 
     @responses.activate
     def test_get_hosts(self):
@@ -31,10 +47,10 @@ class TestGetJson(unittest.TestCase):
                           {u'name': u'foo'},
                           {u'name': u'bar'}])
         self.assertEqual(len(responses.calls), 2)
-        self.assertEqual(responses.calls[0].request.url,
-                         '%s?per_page=250&page=1' % url)
-        self.assertEqual(responses.calls[1].request.url,
-                         '%s?per_page=250&page=2' % url)
+        self.assertEqualUrl(responses.calls[0].request.url,
+                            '%s?per_page=250&page=1' % url)
+        self.assertEqualUrl(responses.calls[1].request.url,
+                            '%s?per_page=250&page=2' % url)
 
     @responses.activate
     def test_get_facts(self):
@@ -52,8 +68,8 @@ class TestGetJson(unittest.TestCase):
         ret = self.inv._get_facts({'id': 10})
         self.assertEqual(ret, {u'fact2': u'val2', u'fact1': u'val1'})
         self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(responses.calls[0].request.url,
-                         '%s?per_page=250&page=1' % url)
+        self.assertEqualUrl(responses.calls[0].request.url,
+                            '%s?per_page=250&page=1' % url)
 
     @responses.activate
     def test_resolve_params(self):
@@ -72,5 +88,6 @@ class TestGetJson(unittest.TestCase):
                          sorted({'param1': 'value1',
                                  'param2': 'value2'}.items()))
         self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(responses.calls[0].request.url,
-                         '%s?per_page=250&page=1' % url)
+
+        self.assertEqualUrl(responses.calls[0].request.url,
+                            '%s?per_page=250&page=1' % url)

--- a/tests/test_read_settings.py
+++ b/tests/test_read_settings.py
@@ -20,7 +20,7 @@ class TestReadSettings(unittest.TestCase):
         self.assertFalse(self.inv.read_settings())
 
     def test_parse_params(self):
-        with tempfile.NamedTemporaryFile() as t:
+        with tempfile.NamedTemporaryFile(mode='w+') as t:
             print("""
 [foreman]
 url=http://127.0.0.1


### PR DESCRIPTION
I handled the different module names in python3 and python2 using try ... except ImportError: , if this gets too messy we need to introduce a dependency on six.
