### PR TITLE
Support for skip_host_patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,11 @@ by recursively resolving the hostgroups, getting the parameter keys
 and values and doing a Python *string.format()* like replacement on
 it.
 
+If you want to exclude hosts from the inventory you can configure the *skip\_host_patterns* like:
+
+    [ansible]
+    skip_host_patterns = ["somehost", "example.com"]
+
+This excludes hosts with the "somehost" or the "example.com" strings.
+
 [1]: http://docs.ansible.com/intro_dynamic_inventory.html

--- a/foreman.ini
+++ b/foreman.ini
@@ -13,6 +13,8 @@ group_prefix = foreman_
 # Whether to fetch facts from Foreman and store them on the host
 want_facts = True
 
+#skip_host_patterns = ["somehost", "example.com"]
+
 [cache]
 path = .
 max_age = 60


### PR DESCRIPTION
This contains a patch for excluding hosts in the inventory using the skip_host_patterns option.

My usecase for this is to exclude hosts which are added by virt-who (VMware ESX servers) and the Foreman host itself. Maybe it's also handy for other use cases.