### PR TITLE
Specify a static filename for the cache files

### DIFF
--- a/foreman.ini
+++ b/foreman.ini
@@ -15,4 +15,5 @@ want_facts = True
 
 [cache]
 path = .
+filename = foreman_ansible_inventory
 max_age = 60

--- a/foreman_ansible_inventory.py
+++ b/foreman_ansible_inventory.py
@@ -153,11 +153,14 @@ class ForemanInventory(object):
             cache_path = os.path.expanduser(config.get('cache', 'path'))
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             cache_path = '.'
-        (script, ext) = os.path.splitext(os.path.basename(__file__))
-        self.cache_path_cache = cache_path + "/%s.cache" % script
-        self.cache_path_inventory = cache_path + "/%s.index" % script
-        self.cache_path_params = cache_path + "/%s.params" % script
-        self.cache_path_facts = cache_path + "/%s.facts" % script
+        try:
+            cache_filename = os.path.expanduser(config.get('cache', 'filename'))
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            (cache_filename, ext) = os.path.splitext(os.path.basename(__file__))
+        self.cache_path_cache = cache_path + "/%s.cache" % cache_filename
+        self.cache_path_inventory = cache_path + "/%s.index" % cache_filename
+        self.cache_path_params = cache_path + "/%s.params" % cache_filename
+        self.cache_path_facts = cache_path + "/%s.facts" % cache_filename
         try:
             self.cache_max_age = config.getint('cache', 'max_age')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):


### PR DESCRIPTION
With this patch it's possible to specify a static filename for the cache files. This is handy if the dynamic inventory script is used in Ansible Tower. Every time Ansible Tower updates the dynamic inventory it creates and executes a generated temporary script filename. Because it's different every time you get different cache files and can't use the cache.

I added the filename parameter to the the configuration file under the cache section. If the filename parameter isn't specified in the configuration file it uses the original filename.

Maybe this patch is also useful for other users? Feel free to merge it.